### PR TITLE
add talk info for first seminar

### DIFF
--- a/events/2024-AI-Seminar.md
+++ b/events/2024-AI-Seminar.md
@@ -22,7 +22,7 @@ Please reach out to the organizers if you would like to recommend a spearker or 
 
 # Next Presentation
 
-**TITLE (TBA)**
+**Scientific AI surrogate models for simulation and optimization**
 
 <br>Room: Weinberg Auditorium (4500N/I-126)
 <br> Time: 10-11 am ET, Thursday, 03/20/2024
@@ -30,10 +30,20 @@ Please reach out to the organizers if you would like to recommend a spearker or 
 <br>[Dr. Raphaël Pestourie](https://cse.gatech.edu/people/raphael-pestourie)
 
 **Abstract**
-TBA
+
+In this talk, I will showcase how surrogate models accelerate the evaluation of properties of PDE solutions.
+I will present a precise definition of the computational benefit of surrogate models and example surrogate models.
+We will then show how surrogate models can be combined to solve a challenging multiscale problem in optics.
+We will show that, through a synergistic combination of data-driven methods and direct numerical simulations, surrogate-based models present a data-efficient and physics-enhanced approach to simulating and optimizing complex systems.
+This approach has the benefit of being interpretable.
+I will also share ways forward and opportunities where I am actively seeking collaborations.
 
 **Bio**
-TBA
+
+Raphaël Pestourie is an assistant professor at Georgia Tech in the School of Computational Science and Engineering.
+He earned his Ph.D. in Applied Mathematics Harvard University in 2020.
+Prior to Georgia Tech, he was a postdoctoral associate at MIT Mathematics, where he worked closely with the MIT-IBM Watson AI Lab.
+Raphaël’s research synergistically combines data-driven surrogate models and direct numerical simulations to accelerate simulation and optimization of complex systems for AI-driven discoveries.
 
 ---
 **Accelerating Astronomical Discovery: Synergies Between Generative AI, Large Language Models, and Data-Driven Astronomy**

--- a/events/2024-AI-Tutorial.md
+++ b/events/2024-AI-Tutorial.md
@@ -50,11 +50,12 @@ Therefore, please request an entry pass only if you need to attend virtually.
 | Massimiliano Lupo Pasini<br> Staff Scientist<br>Computing and Computational Sciences Directorate, ORNL |
 
 
-**Abstract:** 
+**Abstract**
+
 During the tutorial, we will show how to use HydraGNN (https://github.com/ORNL/HydraGNN), our scalable implementation of multi-task learning graph neural networks developed at Oak Ridge National Laboratory #ORNL as part of the ORNL Artificial Intelligence Initiative.
 After discussing scientific motivations behind the need to develop scalable GNN training to support scientific applications of interest to the US Department of Energy (DOE), we will cover a hands-on session with examples of increasing difficulty. In particular, we will show how HydraGNN can be used to scale the training of GNN models on millions of atomic structures on OLCF-Summit, NERSC-Perlmutter, and OLCF-Frontier. To this day, we achieved linear scaling on these DOE leadership class supercomputing facilities using up to 1,024 GPUs.
 
-**Bio:**
+**Bio**
 
 Massimiliano (Max) Lupo Pasini obtained his Bachelor of Science and Master of Science in Mathematical Engineering at the Politecnico di Milano in Milan, Italy. The focus of his undergraduate and master studies was statistics and discretization techniques and reduction order models for partial differential equations. He obtained his PhD in Applied Mathematics at Emory University in Atlanta (GA) in May 2018. The main topic of his doctorate work was the development of efficient and resilient linear solvers for upcoming computing architectures moving towards exascale. Upon graduation, Max joined the Oak Ridge National Laboratory (ORNL) as a Postdoctoral Researcher Associate in the Scientific Computing Group at the National Center for Computational Sciences (NCCS).
 


### PR DESCRIPTION
This PR introduces the following changes:

- add talk information for the first seminar
- adjust for consistent formatting between tutorials and seminars