### PR TITLE
updated date of Ayana tutorial 2024; added 12/05/2024 seminar; created 2025 Seminar md

### DIFF
--- a/events/2024-AI-Seminar.md
+++ b/events/2024-AI-Seminar.md
@@ -309,6 +309,7 @@ Please reach out if you are interested in presenting at a future event
 | 08-22-2024 | Teams | Dr. Sara Magliacane | University of Amsterdam | Causal representation learning in temporal settings |
 | 10-24-2024 | Teams | Dr. Graham West | Meharry Medical College School | Echoes of Athens: Bringing Advances in AI/ML to Ancient Greek Papyrology |
 | 11-07-2024 | Teams | Dr. Lav Varshney | University of Illinois Urbana-Champaign | Information Lattice Learning |
+| 12-05-2024 | Teams | Fernanda Foertter | Oak Ridge National Laboratory | AI Data Readiness |
 
 <a href="#top"> &#10558; Back to top</a>
 

--- a/events/2024-AI-Tutorial.md
+++ b/events/2024-AI-Tutorial.md
@@ -223,7 +223,7 @@ Please reach out if you are interested in presenting at a future event
 | 06/28/2024 | PI3NN: Uncertainty Quantification for ML models | [Dan Lu](https://www.ornl.gov/staff-profile/dan-lu) <br/> [Siyan Liu](https://www.ornl.gov/staff-profile/siyan-liu) |
 | 07/26/2024 | VAE-NCDE: a generative time series model for probabilistic multivariate time series forecasting | [William L Gurecky](https://www.ornl.gov/staff-profile/william-l-gurecky) |
 | 10/18/2024 | ML-HSIR: Machine Learning based Hyperspectral Image Reconstruction the edge | [Narasinga Rao Miniskar](https://www.ornl.gov/staff-profile/narasinga-r-miniskar) |
-| 11/15/2024 | Intro to causal and explainable models in materials science | [Ayana Ghosh](https://www.ornl.gov/staff-profile/ayana-ghosh) |
+| 12/13/2024 | Intro to causal and explainable models in materials science | [Ayana Ghosh](https://www.ornl.gov/staff-profile/ayana-ghosh) |
 
 <a href="#top"> &#10558; Back to top</a>
 
@@ -236,9 +236,9 @@ td, th {
 }
 </style>
 
-|                |                |                |
-| -------------- | -------------- | -------------- |
-| [![Jong Youl Choi](https://www.ornl.gov/sites/default/files/styles/staff_profile_image_style/public/2021-02/jychoi2_0.png?h=273942d0&itok=wF9lLEZU)](https://www.ornl.gov/staff-profile/jong-youl-choi) | [![Yan Liu](https://www.ornl.gov/sites/default/files/styles/staff_profile_image_style/public/2019-04/liuy8.png?h=5114cd9b&itok=5Nt4keCd)](https://www.ornl.gov/staff-profile/yan-liu) | [![Prasanna Balaprakash](https://www.ornl.gov/sites/default/files/styles/staff_profile_image_style/public/2023-03/BalaprakashProfile_0.jpg?h=17644140&itok=AYUSlKCG)](https://www.ornl.gov/staff-profile/prasanna-balaprakash) |
-| Jong Youl Choi <br> HPC Data Research Scientist <br> Computer Science and Mathematics Division <br> ORNL | Yan Liu<br> Computational Scientist <br> Computational Sciences and Engineering Division <br> ORNL | Prasanna Balaprakash<br> Director of AI Programs <br> Distinguished R&D Staff Scientist<br> Computing and Computational Sciences Directorate, ORNL |
+|                |                |                |                |
+| -------------- | -------------- | -------------- | -------------- |
+| [![Jong Youl Choi](https://www.ornl.gov/sites/default/files/styles/staff_profile_image_style/public/2021-02/jychoi2_0.png?h=273942d0&itok=wF9lLEZU)](https://www.ornl.gov/staff-profile/jong-youl-choi) | [![Yan Liu](https://www.ornl.gov/sites/default/files/styles/staff_profile_image_style/public/2019-04/liuy8.png?h=5114cd9b&itok=5Nt4keCd)](https://www.ornl.gov/staff-profile/yan-liu) | [![Chen Zhang](https://www.ornl.gov/sites/default/files/styles/staff_profile_image_style/public/2020-10/profile_0.png?h=c49a1206&itok=ntQg6NeU)](https://www.ornl.gov/staff-profile/chen-zhang) | [![Prasanna Balaprakash](https://www.ornl.gov/sites/default/files/styles/staff_profile_image_style/public/2023-03/BalaprakashProfile_0.jpg?h=17644140&itok=AYUSlKCG)](https://www.ornl.gov/staff-profile/prasanna-balaprakash) |
+| Jong Youl Choi <br> HPC Data Research Scientist <br> Computer Science and Mathematics Division <br> ORNL | Yan Liu<br> Computational Scientist <br> Computational Sciences and Engineering Division <br> ORNL | Chen Zhang <br> Computational Scientist <br> Computer Science and Mathematics Division <br> ORNL | Prasanna Balaprakash<br> Director of AI Programs <br> Distinguished R&D Staff Scientist<br> Computing and Computational Sciences Directorate, ORNL |
 
 <a href="#top"> &#10558; Back to top</a>

--- a/events/2025-AI-Seminar.md
+++ b/events/2025-AI-Seminar.md
@@ -1,0 +1,77 @@
+---
+layout: default
+title: ORNL's AI Seminar Series <br/> 
+description: Organized by  AI Initiative <br/>
+             10–11 am ET <br/> 
+             Every Other Thursday, January-December, 2025 <br/> 
+             Hybrid (Onsite & Virtual) <br/>
+             
+permalink: /events/ai-initiative-seminar-2025/
+tags: events
+---
+
+# About
+
+The ORNL AI Seminar Series (Biweekly/Hybrid), organized by the [AI Initiative](https://www.ornl.gov/ai-initiative), serves as a platform for researchers and engineers from diverse scientific, engineering, and national security backgrounds spanning ORNL, universities, and industry.
+Our main objective is to encourage collaboration with the goal of driving transformative advancements in safe, trustworthy, and energy-efficient AI research and its applications.
+
+The seminar will be held every other Thursday from 10 am to 11 am ET.
+Please reach out to the organizers if you would like to recommend a spearker or give a talk.
+
+<a href="#top"> &#10558; Back to top</a>
+
+# Next Presentation
+
+**Title: Generative Modeling of Molecular Dynamics Trajectories (tentative)**
+
+<br>Location: Building 5700, Room (TBD)
+<br> Time: 11:00 a.m. - 12 p.m. ET, Thursday, 01/23/2025
+<br>[Bowen Jing](https://people.csail.mit.edu/bjing/)
+
+**Abstract**
+
+TBD
+
+**Bio**
+
+TBD
+
+<a href="#top"> &#10558; Back to top</a>
+
+---
+
+# Upcoming Presentations
+
+# Past Presentation
+
+# Schedule
+
+<!---
+The table should be update routein to reflect the upcoming events, and the past events should be at the bottom of the table.
+-->
+
+Please reach out if you are interested in presenting at a future event
+
+|      Date      |    Location    |        Name            |          Affilication           |      Talk      |
+| :------------: | :------------: | :--------------------: | :-----------------------------: | :------------: |
+| 01-23-2025 | Teams | Bowen Jing | Massachusetts Institute of Technology | Generative Modeling of Molecular Dynamics Trajectories |
+| 02-06-2025 | Teams | Ayush Chopra | Massachusetts Institute of Technology | TBD |
+| 02-13-2025 | Teams | Xiaolei Huang| University of Memphis | TBD |
+
+<a href="#top"> &#10558; Back to top</a>
+
+# Organization
+
+For questions, please contact us.
+<style>
+td, th {
+   border: none!important;
+}
+</style>
+
+|                |                |                |                |
+| -------------- | -------------- | -------------- | -------------- |
+| [![Yan Liu](https://www.ornl.gov/sites/default/files/styles/staff_profile_image_style/public/2019-04/liuy8.png?h=5114cd9b&itok=5Nt4keCd)](https://www.ornl.gov/staff-profile/yan-liu) | [![Jong Youl Choi](https://www.ornl.gov/sites/default/files/styles/staff_profile_image_style/public/2021-02/jychoi2_0.png?h=273942d0&itok=wF9lLEZU)](https://www.ornl.gov/staff-profile/jong-youl-choi) | [![Chen Zhang](https://www.ornl.gov/sites/default/files/styles/staff_profile_image_style/public/2020-10/profile_0.png?h=c49a1206&itok=ntQg6NeU)](https://www.ornl.gov/staff-profile/chen-zhang) | [![Prasanna Balaprakash](https://www.ornl.gov/sites/default/files/styles/staff_profile_image_style/public/2023-03/BalaprakashProfile_0.jpg?h=17644140&itok=AYUSlKCG)](https://www.ornl.gov/staff-profile/prasanna-balaprakash) |
+| Yan Liu <br> Computational Scientist <br> Computational Sciences & Engineering Division <br> ORNL | Jong Youl Choi <br> HPC Data Research Scientist <br> Computer Science and Mathematics Division <br> ORNL | Chen Zhang <br> Computational Scientist <br> Computer Science and Mathematics Division <br> ORNL | Prasanna Balaprakash<br> Director of AI Programs <br> Distinguished R&D Staff Scientist<br> Computing and Computational Sciences Directorate, ORNL |
+
+<a href="#top"> &#10558; Back to top</a>

--- a/events/2025-AI-Seminar.md
+++ b/events/2025-AI-Seminar.md
@@ -54,9 +54,9 @@ Please reach out if you are interested in presenting at a future event
 
 |      Date      |    Location    |        Name            |          Affilication           |      Talk      |
 | :------------: | :------------: | :--------------------: | :-----------------------------: | :------------: |
-| 01-23-2025 | Teams | Bowen Jing | Massachusetts Institute of Technology | Generative Modeling of Molecular Dynamics Trajectories |
-| 02-06-2025 | Teams | Ayush Chopra | Massachusetts Institute of Technology | TBD |
-| 02-13-2025 | Teams | Xiaolei Huang| University of Memphis | TBD |
+| 01-23-2025 | TBD | Bowen Jing | Massachusetts Institute of Technology | Generative Modeling of Molecular Dynamics Trajectories |
+| 02-06-2025 | On Site | Ayush Chopra | Massachusetts Institute of Technology | TBD |
+| 02-13-2025 | TBD | Xiaolei Huang| University of Memphis | TBD |
 
 <a href="#top"> &#10558; Back to top</a>
 

--- a/events/2025-AI-Seminar.md
+++ b/events/2025-AI-Seminar.md
@@ -26,7 +26,7 @@ Please reach out to the organizers if you would like to recommend a spearker or 
 
 <br>Location: Building 5700, Room (TBD)
 <br> Time: 11:00 a.m. - 12 p.m. ET, Thursday, 01/23/2025
-<br>[Bowen Jing](https://people.csail.mit.edu/bjing/)
+<br>Speaker: [Bowen Jing](https://people.csail.mit.edu/bjing/)
 
 **Abstract**
 


### PR DESCRIPTION
Changes:

- *2024-AI-Tutorial.md*: updated date for the last tutorial of 2024; 
- *2024-AI-Seminar.md*: added 12/05/2024 seminar entry; 
- *2025-AI-Seminar.md*: created 2025 AI Seminar md with 3 confirmed talks info