### PR TITLE
updated events/2025-AI-Seminar.md with the next talk info. 

### DIFF
--- a/events/2025-AI-Seminar.md
+++ b/events/2025-AI-Seminar.md
@@ -2,7 +2,7 @@
 layout: default
 title: ORNL's AI Seminar Series <br/> 
 description: Organized by  AI Initiative <br/>
-             10–11 am ET <br/> 
+             11am - noon ET <br/> 
              Every Other Thursday, January-December, 2025 <br/> 
              Hybrid (Onsite & Virtual) <br/>
              
@@ -15,31 +15,26 @@ tags: events
 The ORNL AI Seminar Series (Biweekly/Hybrid), organized by the [AI Initiative](https://www.ornl.gov/ai-initiative), serves as a platform for researchers and engineers from diverse scientific, engineering, and national security backgrounds spanning ORNL, universities, and industry.
 Our main objective is to encourage collaboration with the goal of driving transformative advancements in safe, trustworthy, and energy-efficient AI research and its applications.
 
-The seminar will be held every other Thursday from 10 am to 11 am ET.
+The seminar will be held every other Thursday from 11 am to 12 pm ET.
 Please reach out to the organizers if you would like to recommend a spearker or give a talk.
 
 <a href="#top"> &#10558; Back to top</a>
 
 # Next Presentation
 
-**Title: Problems with preparing data for AI workloads **
+**Denoising Generative Modeling for Molecular Structures and Dynamics**
 
-<br>Location: Building 5700, Room (TBD)
-<br> Time: 11:00 a.m. - 12 p.m. ET, Thursday, 01/09/2025
-<br>Speaker: [Fernanda Foertter](https://impact.ornl.gov/en/persons/fernanda-foertter)
-
-|         |
-| ------- |
-| <img src="https://foertter.com/wp-content/uploads/2023/01/22-1116oraclenvidia42921-edited.jpg" width="300" /> |
-| Fernanda Foertter <br>Senior HPC Engineer <br>Computational Sciences and Engineering Division, ORNL |
+<br>Location: Building 5700, room TBD
+<br> Time: 11:00 a.m. - 12 p.m. ET, Thursday, 01/23/2025
+<br>Speaker: [Bowen Jing](https://people.csail.mit.edu/bjing/), Electrical Engineering and Computer Science, MIT
 
 **Abstract**
 
-Preparing data for AI workloads is to put it mildly, awful. Foundational models are best with huge amounts of data but depending on the domain this task can very dramatically in difficulty. This talk will explore the complexities of data preparation for AI and will discuss common tools and methods used from several people surveyed and interviewed for this talk. This talk will also include a mini-workshop where all attendees can share preferred methods and tools with the goal of building community at ORNL.
+The three-dimensional structure and dynamics of molecules yields crucial insights into their chemical properties and biological functions. In this talk, we will discuss how denoising generative modeling has provided a novel and powerful paradigm for the prediction and sampling of molecular structures and dynamics.  Our work is often guided by considerations of physical symmetry and constrained degrees of freedom, requiring extensions of well-known methods to non-Euclidean spaces which best describe molecular flexibility. We will first show how diffusion over torsional coordinates lays the groundwork for modeling small, druglike molecules. Second, we combine this framework with rigid body motions to learn molecular docking to protein structures. Third, we address conformational sampling of proteins and successfully emulate ensembles from molecular dynamics at reduced computational cost. Finally, we discuss video-like modeling of whole molecular dynamics trajectories, enabling multipurpose generative models trained on simulated data.
 
 **Bio**
 
-Fernanda has been in the intersection of scientific computing data wraggling for 15 years. She has a background in physics and molecular dynamics but later transitioned into genomics and healthcare data. Fernanda was at ORNL previously and worked on CORAL and ECP projects and led the training efforts to migrate applications from CPU to GPU on Titan and Summit. After 6 years in industry Fernanda recently returned to ORNL to continue contributing to the mission of the lab and is currently a member of the Scalable Biomedical Simulation group working on MOSSAIC. She has a penchant for building communities of practice and hopes to build one that helps improve how we do data engineering.
+Bio: Bowen Jing is a 4th year Ph.D. candidate in Electrical Engineering and Computer Science at MIT, co-advised by Tommi Jaakkola and Bonnie Berger. He works on deep learning for structural biology and drug discovery, with a focus on generative models and molecular simulation. He is also a DOE Computational Science Graduate Fellow and completed a practicum in the X Computational Physics Division at at Los Alamos National Laboratory. 
 
 <a href="#top"> &#10558; Back to top</a>
 
@@ -56,14 +51,36 @@ Please reach out if you are interested in presenting at a future event
 |      Date      |    Location    |        Name            |          Affilication           |      Talk      |
 | :------------: | :------------: | :--------------------: | :-----------------------------: | :------------: |
 | 01-09-2025 | Virtual | Fernanda Foertter | ORNL | Problems with preparing data for AI workloads |
-| 01-23-2025 | TBD | Bowen Jing | Massachusetts Institute of Technology | Generative Modeling of Molecular Dynamics Trajectories |
-| 02-06-2025 | TBD | Ayush Chopra | Massachusetts Institute of Technology | TBD |
+| 01-23-2025 | On Site | Bowen Jing | Massachusetts Institute of Technology | Denoising Generative Modeling for Molecular Structures and Dynamics |
+| 02-06-2025 | On Site | Ayush Chopra | Massachusetts Institute of Technology | TBD |
 | 02-13-2025 | Virtual | Xiaolei Huang| University of Memphis | TBD |
 | 02-27-2025 | Virtual | Dong Li | University of California, Merced | TBD |
 
 <a href="#top"> &#10558; Back to top</a>
 
 # Past Presentations
+
+---
+
+**Problems with preparing data for AI workloads**
+
+<br>Location: virtual (MS Teams)
+<br> Time: 11:00 a.m. - 12 p.m. ET, Thursday, 01/09/2025
+<br>Speaker: [Fernanda Foertter](https://impact.ornl.gov/en/persons/fernanda-foertter)
+
+|         |
+| ------- |
+| <img src="https://foertter.com/wp-content/uploads/2023/01/22-1116oraclenvidia42921-edited.jpg" width="300" /> |
+| Fernanda Foertter <br>Senior HPC Engineer <br>Computational Sciences and Engineering Division, ORNL |
+
+**Abstract**
+
+Preparing data for AI workloads is to put it mildly, awful. Foundational models are best with huge amounts of data but depending on the domain this task can very dramatically in difficulty. This talk will explore the complexities of data preparation for AI and will discuss common tools and methods used from several people surveyed and interviewed for this talk. This talk will also include a mini-workshop where all attendees can share preferred methods and tools with the goal of building community at ORNL.
+
+**Bio**
+
+Fernanda has been in the intersection of scientific computing data wraggling for 15 years. She has a background in physics and molecular dynamics but later transitioned into genomics and healthcare data. Fernanda was at ORNL previously and worked on CORAL and ECP projects and led the training efforts to migrate applications from CPU to GPU on Titan and Summit. After 6 years in industry Fernanda recently returned to ORNL to continue contributing to the mission of the lab and is currently a member of the Scalable Biomedical Simulation group working on MOSSAIC. She has a penchant for building communities of practice and hopes to build one that helps improve how we do data engineering.
+
 
 <a href="#top"> &#10558; Back to top</a>
 


### PR DESCRIPTION
updated events/2025-AI-Seminar.md with the next talk info. Also updated seminar time for year 2025.